### PR TITLE
feat(checkin): Add manual ticket check-in by number

### DIFF
--- a/src/components/checkin/CheckInByTicketNumber.tsx
+++ b/src/components/checkin/CheckInByTicketNumber.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useState } from "react";
+import { useCheckin } from "@/hooks/useCheckin";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  CheckCircle,
+  XCircle,
+  AlertCircle,
+  Loader2,
+  Ticket,
+} from "lucide-react";
+import {
+  CheckInStatus,
+  type CheckIn,
+  type CheckInByTicketNumberRequest,
+} from "@/types/checkin";
+
+export function CheckInByTicketNumber({ eventId }: { eventId: string }) {
+  const [ticketNumber, setTicketNumber] = useState("");
+  const [checkInResult, setCheckInResult] = useState<CheckIn | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { useCheckInByTicketNumber } = useCheckin();
+  const checkInMutation = useCheckInByTicketNumber(eventId);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!ticketNumber.trim()) {
+      setError("Please enter a ticket number.");
+      return;
+    }
+    setError(null);
+    setCheckInResult(null);
+
+    const request: CheckInByTicketNumberRequest = {
+      ticket_number: `TKT-${ticketNumber.trim()}`,
+    };
+
+    try {
+      const response = await checkInMutation.mutateAsync(request);
+      if (response.result) {
+        setCheckInResult(response.result);
+      } else {
+        setError(response.message || "An unknown error occurred.");
+      }
+    } catch (err: any) {
+      setError(err.message || "Failed to check in ticket.");
+    }
+  };
+
+  const getStatusIcon = (status: CheckInStatus) => {
+    switch (status) {
+      case CheckInStatus.SUCCESS:
+        return <CheckCircle className="h-8 w-8 text-green-600" />;
+      case CheckInStatus.FAILED:
+      case CheckInStatus.INVALID_QR:
+      case CheckInStatus.WRONG_EVENT:
+        return <XCircle className="h-8 w-8 text-red-600" />;
+      case CheckInStatus.DUPLICATE:
+        return <AlertCircle className="h-8 w-8 text-yellow-600" />;
+      default:
+        return null;
+    }
+  };
+
+  const getStatusColor = (status: CheckInStatus) => {
+    switch (status) {
+      case CheckInStatus.SUCCESS:
+        return "bg-green-50 border-green-200 dark:bg-green-950/20 dark:border-green-800";
+      case CheckInStatus.FAILED:
+      case CheckInStatus.INVALID_QR:
+      case CheckInStatus.WRONG_EVENT:
+        return "bg-red-50 border-red-200 dark:bg-red-950/20 dark:border-red-800";
+      case CheckInStatus.DUPLICATE:
+        return "bg-yellow-50 border-yellow-200 dark:bg-yellow-950/20 dark:border-yellow-800";
+      default:
+        return "bg-muted border-border";
+    }
+  };
+
+  const getStatusText = (status: CheckInStatus) => {
+    switch (status) {
+      case CheckInStatus.SUCCESS:
+        return "Valid Ticket - Check-in Successful";
+      case CheckInStatus.FAILED:
+        return "Invalid Ticket";
+      case CheckInStatus.DUPLICATE:
+        return "Ticket Already Used";
+      case CheckInStatus.INVALID_QR:
+        return "Invalid QR Code";
+      case CheckInStatus.WRONG_EVENT:
+        return "Wrong Event Ticket";
+      case CheckInStatus.EVENT_NOT_STARTED:
+        return "Event Not Started";
+      case CheckInStatus.EVENT_ENDED:
+        return "Event Has Ended";
+      default:
+        return "Unknown Status";
+    }
+  };
+
+  return (
+    <div className="p-6 border-t border-border">
+      <div className="flex items-center mb-4">
+        <Ticket className="h-6 w-6 text-primary mr-2" />
+        <h2 className="text-xl font-semibold text-foreground">
+          Manual Check-in
+        </h2>
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="ticket-number">Ticket Number</Label>
+          <div className="flex items-center">
+            <span className="inline-flex items-center px-3 py-2 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm">
+              TKT-
+            </span>
+            <Input
+              id="ticket-number"
+              type="text"
+              value={ticketNumber}
+              onChange={(e) => setTicketNumber(e.target.value)}
+              placeholder="AB12XXXX"
+              className="rounded-l-none w-full"
+            />
+          </div>
+        </div>
+        <Button
+          type="submit"
+          disabled={checkInMutation.isPending}
+          className="w-full"
+        >
+          {checkInMutation.isPending ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : null}
+          Check In
+        </Button>
+      </form>
+
+      {checkInMutation.isPending && (
+        <div className="mt-6 p-6 bg-blue-50 dark:bg-blue-950/20 border-2 border-blue-200 dark:border-blue-800 rounded-lg">
+          <div className="flex items-center justify-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 dark:border-blue-400 mr-3"></div>
+            <div className="text-center">
+              <h3 className="text-lg font-semibold text-blue-900 dark:text-blue-100">
+                Verifying Ticket...
+              </h3>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="mt-4 text-red-600 dark:text-red-400 text-sm">
+          {error}
+        </div>
+      )}
+
+      {checkInResult && (
+        <div
+          className={`mt-6 border-2 rounded-lg p-6 ${getStatusColor(
+            checkInResult.status
+          )}`}
+        >
+          <div className="flex items-center justify-center mb-4">
+            {getStatusIcon(checkInResult.status)}
+          </div>
+          <h3 className="text-lg font-semibold text-center mb-6 text-foreground">
+            {getStatusText(checkInResult.status)}
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Ticket Number
+              </Label>
+              <p className="font-mono text-sm bg-muted p-2 rounded border border-border mt-1 text-foreground">
+                {checkInResult.ticket_details?.ticket_number}
+              </p>
+            </div>
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Ticket Type
+              </Label>
+              <p className="font-medium mt-1 text-foreground">
+                {checkInResult.ticket_details?.ticket_type.name}
+              </p>
+            </div>
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Checked in by
+              </Label>
+              <p className="font-semibold mt-1 text-foreground">
+                {checkInResult.checked_in_by_details?.name}
+              </p>
+            </div>
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Event
+              </Label>
+              <p className="font-medium mt-1 text-foreground">
+                {checkInResult.event_details?.title}
+              </p>
+            </div>
+            <div>
+              <Label className="text-sm font-medium text-muted-foreground">
+                Check-in Time
+              </Label>
+              <p className="text-sm text-muted-foreground mt-1">
+                {checkInResult.check_in_time}
+              </p>
+            </div>
+          </div>
+          <Button
+            onClick={() => setCheckInResult(null)}
+            className="w-full mt-6"
+            variant="outline"
+          >
+            Clear Result
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/checkin/CheckInByTicketNumber.tsx
+++ b/src/components/checkin/CheckInByTicketNumber.tsx
@@ -17,6 +17,7 @@ import {
   type CheckIn,
   type CheckInByTicketNumberRequest,
 } from "@/types/checkin";
+import { formatDateTime } from "@/lib/utils";
 
 export function CheckInByTicketNumber({ eventId }: { eventId: string }) {
   const [ticketNumber, setTicketNumber] = useState("");
@@ -114,7 +115,7 @@ export function CheckInByTicketNumber({ eventId }: { eventId: string }) {
         <div className="space-y-2">
           <Label htmlFor="ticket-number">Ticket Number</Label>
           <div className="flex items-center">
-            <span className="inline-flex items-center px-3 py-2 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm">
+            <span className="inline-flex items-center px-3 py-2 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 sm:text-sm dark:bg-red-950/10 dark:border-red-900/20 dark:text-gray-400">
               TKT-
             </span>
             <Input
@@ -122,7 +123,7 @@ export function CheckInByTicketNumber({ eventId }: { eventId: string }) {
               type="text"
               value={ticketNumber}
               onChange={(e) => setTicketNumber(e.target.value)}
-              placeholder="AB12XXXX"
+              placeholder="AB12X..."
               className="rounded-l-none w-full"
             />
           </div>
@@ -208,7 +209,7 @@ export function CheckInByTicketNumber({ eventId }: { eventId: string }) {
                 Check-in Time
               </Label>
               <p className="text-sm text-muted-foreground mt-1">
-                {checkInResult.check_in_time}
+                {formatDateTime(checkInResult.check_in_time)}
               </p>
             </div>
           </div>

--- a/src/components/checkin/CheckInContent.tsx
+++ b/src/components/checkin/CheckInContent.tsx
@@ -24,6 +24,8 @@ import {
 import { useState, useEffect } from "react";
 import { useMobile } from "@/hooks/use-mobile";
 
+import { CheckInByTicketNumber } from "@/components/checkin/CheckInByTicketNumber";
+
 interface QRScanResult {
   text: string;
   timestamp: Date;
@@ -50,7 +52,7 @@ export function CheckInContent({ eventId }: { eventId: string }) {
 
   useEffect(() => {
     refetch();
-  }, [queryParams]);
+  }, [queryParams, refetch]);
 
   const { data: stats, isLoading: isLoadingStats } = useCheckInStats(eventId);
   const scanTicketMutation = useScanTicket(eventId);
@@ -398,6 +400,7 @@ export function CheckInContent({ eventId }: { eventId: string }) {
             </div>
           )}
         </div>
+        <CheckInByTicketNumber eventId={eventId} />
       </div>
 
       {/* Check-in History */}

--- a/src/components/checkin/CheckInContent.tsx
+++ b/src/components/checkin/CheckInContent.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/types/checkin";
 import { useState, useEffect } from "react";
 import { useMobile } from "@/hooks/use-mobile";
-
+import { formatDateTime } from "@/lib/utils";
 import { CheckInByTicketNumber } from "@/components/checkin/CheckInByTicketNumber";
 
 interface QRScanResult {
@@ -346,7 +346,7 @@ export function CheckInContent({ eventId }: { eventId: string }) {
                     Check-in Time
                   </label>
                   <p className="text-sm text-muted-foreground mt-1">
-                    {scannedTicket?.check_in_time}
+                    {formatDateTime(scannedTicket?.check_in_time)}
                   </p>
                 </div>
 

--- a/src/hooks/useCheckin.ts
+++ b/src/hooks/useCheckin.ts
@@ -1,4 +1,8 @@
-import type { CheckInQueryParams, ScanTicketRequest } from "@/types/checkin";
+import type {
+  CheckInByTicketNumberRequest,
+  CheckInQueryParams,
+  ScanTicketRequest,
+} from "@/types/checkin";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { checkinService } from "@/services/checkin.service";
@@ -53,6 +57,18 @@ export const useCheckin = () => {
     });
   };
 
+  const useCheckInByTicketNumber = (eventId: string) => {
+    return useMutation({
+      mutationFn: (data: CheckInByTicketNumberRequest) =>
+        checkinService.checkInByTicketNumber(eventId, data),
+      onSuccess: () => {
+        queryClient.invalidateQueries({ queryKey: ["checkins", eventId] });
+        queryClient.invalidateQueries({ queryKey: ["checkin-stats", eventId] });
+      },
+      retry: false,
+    });
+  };
+
   return {
     useCheckIns,
     useCheckIn,
@@ -60,5 +76,6 @@ export const useCheckin = () => {
     useCheckInStats,
     useDeviceCheckIns,
     useUserCheckIns,
+    useCheckInByTicketNumber,
   };
 };

--- a/src/services/checkin.service.ts
+++ b/src/services/checkin.service.ts
@@ -1,4 +1,5 @@
 import {
+  CheckInByTicketNumberRequest,
   CheckInQueryParams,
   CheckInResponse,
   CheckInStatsResponse,
@@ -46,6 +47,16 @@ class CheckinService {
   ): Promise<CheckInResponse> {
     return apiClient.post<CheckInResponse>(
       `${this.baseUrl}/events/${eventId}/checkin/scan_ticket`,
+      data
+    );
+  }
+
+  public async checkInByTicketNumber(
+    eventId: string,
+    data: CheckInByTicketNumberRequest
+  ): Promise<CheckInResponse> {
+    return apiClient.post<CheckInResponse>(
+      `${this.baseUrl}/events/${eventId}/checkin/checkin_by_ticket_number`,
       data
     );
   }

--- a/src/types/checkin.ts
+++ b/src/types/checkin.ts
@@ -119,6 +119,10 @@ export interface ScanTicketRequest {
   };
 }
 
+export interface CheckInByTicketNumberRequest {
+  ticket_number: string;
+}
+
 export interface RegisterDeviceRequest {
   name: string;
   device_id: string;


### PR DESCRIPTION
This commit introduces the ability for event staff to manually check in attendees by their ticket number.

    Key changes:

    - **`CheckInByTicketNumber.tsx`:** A new component that provides a form for entering a ticket number. It handles the API request and displays the check-in result.
    - **`CheckInContent.tsx`:** The new `CheckInByTicketNumber` component is integrated into the main check-in page.
    - **`useCheckin.ts`:** A new `useCheckInByTicketNumber` hook has been added to handle the mutation for checking in a ticket by its number.
    - **`checkin.service.ts`:** The `checkinService` has been updated to include a `checkInByTicketNumber` method that sends the request to the API.
    - **`checkin.ts`:** The `CheckInByTicketNumberRequest` type has been added.
    - The ticket number input field is prepopulated with "TKT-" to improve user experience.

    This feature provides a fallback for situations where QR code scanning is not possible, improving the robustness of the check-in process.